### PR TITLE
kernel: ignore symversion checks and vermagic checks

### DIFF
--- a/kernel-5.10/kernel/module.c
+++ b/kernel-5.10/kernel/module.c
@@ -1372,9 +1372,9 @@ static int check_version(const struct load_info *info,
 	return 1;
 
 bad_version:
-	pr_warn("%s: disagrees about version of symbol %s\n",
+	pr_warn("%s: disagrees about version of symbol %s, but ignored.\n",
 	       info->name, symname);
-	return 0;
+	return 1;
 }
 
 static inline int check_modstruct_version(const struct load_info *info,
@@ -3311,9 +3311,9 @@ static int check_modinfo(struct module *mod, struct load_info *info, int flags)
 		if (err)
 			return err;
 	} else if (!same_magic(modmagic, vermagic, info->index.vers)) {
-		pr_err("%s: version magic '%s' should be '%s'\n",
+		pr_warn("%s: version magic '%s' should be '%s'\n",
 		       info->name, modmagic, vermagic);
-		return -ENOEXEC;
+		//return -ENOEXEC;
 	}
 
 	if (!get_modinfo(info, "intree")) {


### PR DESCRIPTION
If this still doesn't boot, well maybe something wrong inside the kernel source itself